### PR TITLE
Switch to newer server url

### DIFF
--- a/src/Aspsms.php
+++ b/src/Aspsms.php
@@ -19,7 +19,7 @@ class Aspsms
     const VERSION = '1.0.3';
 
     /**
-     * @var string Contains the services url (status 30.01.2013)
+     * @var string Contains the services url (status 26.06.2017)
      */
     public $server = "https://soap.aspsms.com/aspsmsx2.asmx/";
 

--- a/src/Aspsms.php
+++ b/src/Aspsms.php
@@ -21,7 +21,7 @@ class Aspsms
     /**
      * @var string Contains the services url (status 30.01.2013)
      */
-    public $server = "https://webservice.aspsms.com/aspsmsx2.asmx/";
+    public $server = "https://soap.aspsms.com/aspsmsx2.asmx/";
 
     /**
      * @var string Contains the userkey which is provided from the aspsms.com webpage under the menu

--- a/src/Request.php
+++ b/src/Request.php
@@ -109,6 +109,9 @@ class Request
         curl_setopt_array($curl, $this->options);
         // excute the curl and write response into $response
         $response = curl_exec($curl);
+        if (!$response) {
+            $response = curl_error($curl);
+        }
         // close the curl connection
         curl_close($curl);
         // see if response is xml valid (else we have a basic api error)

--- a/src/Request.php
+++ b/src/Request.php
@@ -107,9 +107,10 @@ class Request
         $curl = curl_init();
         // set all options into curl object from $options
         curl_setopt_array($curl, $this->options);
-        // excute the curl and write response into $response
+        // execute the curl and write response into $response
         $response = curl_exec($curl);
-        if (!$response) {
+        // populate response with curl error message if curl_exec failed
+        if ($response === false) {
             $response = curl_error($curl);
         }
         // close the curl connection

--- a/tests/RequestErrorTest.php
+++ b/tests/RequestErrorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Aspsms\Test;
+
+class RequestErrorTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected $request;
+    
+    protected $badSSLUrl = "https://webservice.aspsms.com/aspsmsx2.asmx/";
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->request = new \Aspsms\Request($this->badSSLUrl);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessageRegExp /Invalid API Response .*SSL.?/
+     */
+    public function testInvalidSSL()
+    {
+        $this->request->transfer();
+    }
+
+}


### PR DESCRIPTION
I recently had some problems with newer server environments who seemed to have problems with the older URL that uses some outdated SSL technology. 
Additionally, to make such errors more obvious, I added some code to see the curl error message in the "Invalid API response" exception message.